### PR TITLE
Fix error when key contains escape sequences

### DIFF
--- a/python3/zotero.py
+++ b/python3/zotero.py
@@ -464,15 +464,15 @@ class ZoteroEntries:
             lastname = re.sub('\W', '', lastname)
             titlew = re.sub('\W', '', titlew)
             key = self._cite
-            key = re.sub('{author}', lastname.lower(), key)
-            key = re.sub('{Author}', lastname.title(), key)
-            key = re.sub('{authors}', lastnames.lower(), key)
-            key = re.sub('{Authors}', lastnames.title(), key)
-            key = re.sub('{year}', re.sub('^[0-9][0-9]', '', year), key)
-            key = re.sub('{Year}', year, key)
-            key = re.sub('{title}', titlew.lower(), key)
-            key = re.sub('{Title}', titlew.title(), key)
-            key = re.sub(' ', '', key)
+            key = key.replace('{author}', lastname.lower(), 1)
+            key = key.replace('{Author}', lastname.title(), 1)
+            key = key.replace('{authors}', lastnames.lower(), 1)
+            key = key.replace('{Authors}', lastnames.title(), 1)
+            key = key.replace('{year}', re.sub('^[0-9][0-9]', '', year), 1)
+            key = key.replace('{Year}', year, 1)
+            key = key.replace('{title}', titlew.lower(), 1)
+            key = key.replace('{Title}', titlew.title(), 1)
+            key = key.replace(' ', '', 1)
             self._e[k]['citekey'] = key
 
 


### PR DESCRIPTION
Python's regex engine tries to interpet escape sequences inside the
replacement string, and throws an exception if it finds an invalid one.
However the replacement is meant to be a literal string here, we do not
want to process anything that would look like an escape sequence.

Fixes this error on startup:
```
Error detected while processing function zotcite#Init[24]..zotcite#GlobalInit[17]..provider#python3#Call:
line   18:
Traceback (most recent call last):
  File "/usr/lib/python3.7/sre_parse.py", line 1015, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\s'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/edwin/.vim/pack/my-plugins/start/zotcite/python3/zotero.py", line 265, in __init__
    self._load_zotero_data()
  File "/home/edwin/.vim/pack/my-plugins/start/zotcite/python3/zotero.py", line 313, in _load_zotero_data
    self._calculate_citekeys()
  File "/home/edwin/.vim/pack/my-plugins/start/zotcite/python3/zotero.py", line 469, in _calculate_citekeys
    key = re.sub('{authors}', lastnames.lower(), key)
  File "/usr/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python3.7/re.py", line 309, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.7/re.py", line 300, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.7/sre_parse.py", line 1018, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \s at position
```

With this change `zotcite` becomes usable, and things like `<leader>zi` and `<leader>zo` produce plausible results with author names and titles.
Omnicompletion shows only authornames, no titles, so there might be more bugs, but at least zotcite started working now for me.