### PR TITLE
Leave room for title for completions with lots of authors

### DIFF
--- a/python3/zotero.py
+++ b/python3/zotero.py
@@ -501,10 +501,13 @@ class ZoteroEntries:
 
     @classmethod
     def _get_compl_line(cls, e):
-        if e['alastnm'] == '':
+        alastnm = e['alastnm']
+        if alastnm == '':
             line = e['zotkey'] + '#' + e['citekey'] + '\x09 \x09(' + e['year'] + ') ' + e['title']
         else:
-            line = e['zotkey'] + '#' + e['citekey'] + '\x09' + e['alastnm'] + '\x09(' + e['year'] + ') ' + e['title']
+            if len(alastnm) > 40:
+                alastnm = alastnm[:40] + "…"
+            line = e['zotkey'] + '#' + e['citekey'] + '\x09' + alastnm + '\x09(' + e['year'] + ') ' + e['title']
         return line
 
     def GetMatch(self, ptrn, d):


### PR DESCRIPTION
I have a few zotero entries where listing all the authors' lastnames
results in a string longer than my terminal width (172 chars), leaving
no room for the title.
Because Vim aligns all entries (even not yet visible ones) this causes
all the titles to be missing from the completion popup in a terminal
based nvim. (nvim-qt does show it, alignment works differently there).

Limit the maximum length of the authors' lastnames `alastnm` to 40 to
leave some room for the title. Indicate truncation with an UTF-8
ellipsis.

You can use this Zotero entry for testing:
https://dl.acm.org/citation.cfm?id=2491245

