### PR TITLE
Update zotref to tolerate new citation fields

### DIFF
--- a/python3/zotref
+++ b/python3/zotref
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     j = json.load(io.StringIO(i))
 
     # Get all citations from the markdown document
-    cites = re.findall('"citationId":"([^"]+)","citationHash', i)
+    cites = re.findall('"citationId":"([^"]+)","citation', i)
     c = sorted(set(cites))
 
     # Get the references for the found citekeys formatted as the YAML and put


### PR DESCRIPTION
As described in #19, the format of the citation fields has changed in the latest Pandoc API. This change allows it to work with the newer fields and should remain backwards compatible, although I have not tested it yet.