### PR TITLE
Add ability to open PDFs in Zotero

### DIFF
--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -223,8 +223,14 @@ function zotcite#GetReferenceData(type)
     endif
 endfunction
 
-function zotcite#TranslateZPath(strg)
+function zotcite#TranslateZPath(strg, zotero_uri = 0)
     let fpath = a:strg
+
+    if a:zotero_uri && a:strg =~? '\.pdf$'
+        let id = substitute(fpath, ':.*', '', '')
+        return 'zotero://open-pdf/library/items/' . id
+    endif
+
     if a:strg =~ ':attachments:'
 	" The user has set Edit / Preferences / Files and Folders / Base directory for linked attachments
 	if g:zotcite_attach_dir == ''
@@ -246,7 +252,7 @@ function zotcite#TranslateZPath(strg)
     return fpath
 endfunction
 
-function zotcite#GetPDFPath(zotkey)
+function zotcite#GetPDFPath(zotkey, zotero_uri = 0)
     let repl = py3eval('ZotCite.GetAttachment("' . a:zotkey . '")')
     if len(repl) == 0
         call zotcite#warning('Got empty list')
@@ -260,7 +266,7 @@ function zotcite#GetPDFPath(zotkey)
         call zotcite#warning('Citation key not found')
     else
         if len(repl) == 1
-            return zotcite#TranslateZPath(repl[0])
+            return zotcite#TranslateZPath(repl[0], a:zotero_uri)
         else
             let idx = 1
             for at in repl
@@ -272,7 +278,7 @@ function zotcite#GetPDFPath(zotkey)
             endfor
             let idx = input('Your choice: ')
             if idx != '' && idx >= 1 && idx <= len(repl)
-                return zotcite#TranslateZPath(repl[idx - 1])
+                return zotcite#TranslateZPath(repl[idx - 1], a:zotero_uri)
             endif
         endif
     endif
@@ -294,7 +300,7 @@ endfunction
 
 function zotcite#OpenAttachment()
     let zotkey = zotcite#GetCitationKey()
-    let fpath = zotcite#GetPDFPath(zotkey)
+    let fpath = zotcite#GetPDFPath(zotkey, g:zotcite_open_in_zotero)
     if fpath != ''
         call system(s:open_cmd . ' "' . fpath . '" &')
     endif

--- a/doc/zotcite.txt
+++ b/doc/zotcite.txt
@@ -20,7 +20,8 @@ Author: Jakson A. Aquino <jalvesaq@gmail.com>
         Syntax highlighting of citation keys                      |zotcite_hl|
         Conceal level                                   |zotcite_conceallevel|
     4.4 File types                                         |zotcite_filetypes|
-    4.5 Quarto render options                                       |:Zrender|
+    4.5 Open attachment in Zotero                     |zotcite_open_in_zotero|
+    4.6 Quarto render options                                       |:Zrender|
  5. Troubleshooting                                  |zotcite_troubleshooting|
 
 
@@ -311,10 +312,26 @@ path to `markdown.vim`:
   autocmd FileType vimwiki source /path/to/zotcite/after/syntax/markdown.vim
 <
 
+						      *zotcite_open_in_zotero*
+4.5 Open attachment in Zotero~
+
+If you want <Plug>ZOpenAttachment to open PDF attachments in Zotero (as
+opposed to your system's default PDF viewer), put the following in your
+|vimrc|:
+>
+  let zotcite_open_in_zotero = 1
+<
+Note that you'll need to have Zotero configured as the default app for
+opening `zotero://` links. On Linux, assuming your Zotero installation
+included a `zotero.desktop` file, you can do the following:
+>
+  xdg-mime default zotero.desktop x-scheme-handler/zotero
+<
+
 						      *zotcite_quarto_preview*
 						       *zotcite_quarto_render*
 								    *:Zrender*
-4.5 Quarto render options [NOT IMPLEMENTED YET]~
+4.6 Quarto render options [NOT IMPLEMENTED YET]~
 
 If editing Quarto documents, Zotcite will automatically run `quarto preview`
 when the document is saved for the first time. Alternatively, whenever the

--- a/plugin/zotcite.vim
+++ b/plugin/zotcite.vim
@@ -6,6 +6,7 @@ if exists(':Zinfo') == 2
     finish
 endif
 let g:zotcite_filetypes = get(g:, 'zotcite_filetypes', ['markdown', 'pandoc', 'rmd', 'quarto'])
+let g:zotcite_open_in_zotero = get(g:, 'zotcite_open_in_zotero', 0)
 augroup zotcite
     autocmd BufNewFile,BufRead * call timer_start(1, "zotcite#Init")
 augroup END


### PR DESCRIPTION
This behavior is off by default and enabled by setting the vim variable
`g:zotcite_open_in_zotero` to `1`.