### PR TITLE
Enable citations in abstract metadata field

### DIFF
--- a/python3/zotref.py
+++ b/python3/zotref.py
@@ -54,6 +54,9 @@ if __name__ == "__main__":
     # and get all citations from the markdown document
     WalkClean(j['blocks'])
 
+    if 'abstract' in j['meta']:
+        WalkClean(j['meta']['abstract'])
+
     c = sorted(set(cites))
 
     if 'bibliography' in j['meta']:


### PR DESCRIPTION
Many quarto journal templates have an `abstract` [field in the metadata](https://github.com/quarto-journals/jasa/blob/c39f0e77a2aabdbd3be4612b215efe7f4cc8dd28/template.qmd#L21). Zotcite citations currently autocomplete there but don't render properly. This enables zotcite to work on the `abstract` metadata field. 