### PR TITLE
 zotcite.vim -- add 'vimwiki' as standard. 

### DIFF
--- a/plugin/zotcite.vim
+++ b/plugin/zotcite.vim
@@ -5,7 +5,7 @@ endif
 if exists(':Zinfo') == 2
     finish
 endif
-let g:zotcite_filetypes = get(g:, 'zotcite_filetypes', ['markdown', 'pandoc', 'rmd', 'quarto'])
+let g:zotcite_filetypes = get(g:, 'zotcite_filetypes', ['markdown', 'pandoc', 'rmd', 'quarto', 'vimwiki'])
 augroup zotcite
     autocmd BufNewFile,BufRead * call timer_start(1, "zotcite#Init")
 augroup END


### PR DESCRIPTION
Hi Jalvesaq, 

Basically as the title suggests. is It possible to just add vimwiki files as a deafult to this since many users may likely use zotero with their wiki files in academia. I haven't tried adding other kinds of wiki syntax to use the plugin as a standard however for vimwiki it is quite useful and requires much less to setup the plugin. 
I know for instance that it is of course possible to add to the configuration options to include other filetypes but as a standard and for ease of use I think it is possible to just add 'vimwiki' as an already useable option. 
Vimwiki supports markdown and mostly means that using something like 'toggleterm.nvim' with 'whichkey.nvim', it is possible to integrate pandoc to convert to pdf/latex/html etc. just with hotkeys. 

This kind of change could also be applied to the cmp plugin for zotero autosuggestions, but I know this optional.