### PR TITLE
Create Command For Running Pandoc From Markdown to PDF

### DIFF
--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -638,7 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<q-args>)
+    command -nargs=2 Zpandoc call zotcite#ConvertFileTypes(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -576,13 +576,14 @@ endfunction
 " :MarkdownToPDF filename.md it will create a PDF file with the same name
 " using pandoc
 
-function zotcite#ConvertFileTypes(inputfile, outputfile)
-    let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
+function zotcite#MarkdownToPDF(filename)
+    let pdfname = substitute(a:filename, '\.md$', '.pdf', '')
+    let cmd = 'pandoc ' . a:filename . ' -s -o ' . pdfname . ' -F zotref.py --citeproc'
     let out = system(cmd)
     if v:shell_error
         call zotcite#warning(substitute(out, '\n', ' ', 'g'))
     else
-        echo 'File created: ' . a:outputfile
+        echo 'PDF file created: ' . pdfname
     endif
   endfunction
 
@@ -638,7 +639,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<q-args>)
+    command -nargs=1 Zpandoc call zotcite#MarkdownToPDF(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -576,8 +576,7 @@ endfunction
 " :MarkdownToPDF filename.md it will create a PDF file with the same name
 " using pandoc
 
-function zotcite#ConvertFileTypes(inputfile, outputfile)
-    let outputfile = substitute(a:inputfile, '\.md$', '.pdf', '')
+function zotcite#ConvertFileTypes(inputmd, outputpdf)
     let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
     let out = system(cmd)
     if v:shell_error
@@ -639,7 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=2 Zpandoc call zotcite#MarkdownToPDF(<q-args>)
+    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<f-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -638,7 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<f-args>)
+    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -572,6 +572,20 @@ function zotcite#CheckBib()
     endif
 endfunction
 
+" Create a function to convert a markdown file to PDF, when user runs
+" :MarkdownToPDF filename.md it will create a PDF file with the same name
+" using pandoc
+
+function zotcite#MarkdownToPDF(filename)
+    let pdfname = substitute(a:filename, '\.md$', '.pdf', '')
+    let cmd = 'pandoc ' . a:filename . ' -s -o ' . pdfname . ' -F zotref.py --citeproc'
+    let out = system(cmd)
+    if v:shell_error
+        call zotcite#warning(substitute(out, '\n', ' ', 'g'))
+    else
+        echo 'PDF file created: ' . pdfname
+    endif
+  endfunction
 function zotcite#GlobalInit()
     if !has('python3')
         let g:zotcite_failed = 'zotcite requires python3'
@@ -624,6 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
+    command -nargs=1 ZMarkdownToPDF call zotcite#MarkdownToPDF(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -576,7 +576,7 @@ endfunction
 " :MarkdownToPDF filename.md it will create a PDF file with the same name
 " using pandoc
 
-function zotcite#MarkdownToPDF(inputfile, outputfile)
+function zotcite#ConvertFileTypes(inputfile, outputfile)
     let outputfile = substitute(a:inputfile, '\.md$', '.pdf', '')
     let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
     let out = system(cmd)
@@ -639,7 +639,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=1 ZMarkdownToPDF call zotcite#MarkdownToPDF(<q-args>)
+    command -nargs=2 Zpandoc call zotcite#MarkdownToPDF(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -638,7 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=2 Zpandoc call zotcite#ConvertFileTypes(<q-args>)
+    command -nargs=+ Zpandoc call zotcite#ConvertFileTypes(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -576,16 +576,17 @@ endfunction
 " :MarkdownToPDF filename.md it will create a PDF file with the same name
 " using pandoc
 
-function zotcite#MarkdownToPDF(filename)
-    let pdfname = substitute(a:filename, '\.md$', '.pdf', '')
-    let cmd = 'pandoc ' . a:filename . ' -s -o ' . pdfname . ' -F zotref.py --citeproc'
+function zotcite#MarkdownToPDF(inputfile, outputfile)
+    let pdfname = substitute(a:inputfile, '\.md$', '.pdf', '')
+    let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
     let out = system(cmd)
     if v:shell_error
         call zotcite#warning(substitute(out, '\n', ' ', 'g'))
     else
-        echo 'PDF file created: ' . pdfname
+        echo 'File created: ' . outputfile
     endif
   endfunction
+
 function zotcite#GlobalInit()
     if !has('python3')
         let g:zotcite_failed = 'zotcite requires python3'

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -576,7 +576,7 @@ endfunction
 " :MarkdownToPDF filename.md it will create a PDF file with the same name
 " using pandoc
 
-function zotcite#ConvertFileTypes(inputmd, outputpdf)
+function zotcite#ConvertFileTypes(inputfile, outputfile)
     let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
     let out = system(cmd)
     if v:shell_error

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -639,7 +639,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=1 Zpandoc call zotcite#MarkdownToPDF(<q-args>)
+    command -nargs=1 -complete=file Zpandoc call zotcite#MarkdownToPDF(<q-args>)
     return 1
 endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -577,7 +577,7 @@ endfunction
 " using pandoc
 
 function zotcite#MarkdownToPDF(inputfile, outputfile)
-    let pdfname = substitute(a:inputfile, '\.md$', '.pdf', '')
+    let outputfile = substitute(a:inputfile, '\.md$', '.pdf', '')
     let cmd = 'pandoc ' . a:inputfile . ' -s -o ' . a:outputfile . ' -F zotref.py --citeproc'
     let out = system(cmd)
     if v:shell_error

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -582,7 +582,7 @@ function zotcite#ConvertFileTypes(inputfile, outputfile)
     if v:shell_error
         call zotcite#warning(substitute(out, '\n', ' ', 'g'))
     else
-        echo 'File created: ' . outputfile
+        echo 'File created: ' . a:outputfile
     endif
   endfunction
 

--- a/autoload/zotcite.vim
+++ b/autoload/zotcite.vim
@@ -638,7 +638,7 @@ function zotcite#GlobalInit()
     command -nargs=1 Znote call zotcite#GetNote(<q-args>)
     command -nargs=+ Zannotations call zotcite#GetAnnotations(<q-args>)
     command -nargs=1 Zpdfnote call zotcite#GetPDFNote(<q-args>)
-    command -nargs=+ Zpandoc call zotcite#ConvertFileTypes(<q-args>)
+    command -nargs=* Zpandoc call zotcite#ConvertFileTypes(<q-args>)
     return 1
 endfunction
 


### PR DESCRIPTION
I added a function `zotcite#MarkdownToPDF` that takes one argument `filename` and then creates an output pdf in the same directory.

Tested functionality in my package manager (lazyvim) and works as expected.