### PR TITLE
Improving title formatting in YAML references

### DIFF
--- a/python3/zotero.py
+++ b/python3/zotero.py
@@ -603,6 +603,14 @@ class ZoteroEntries:
         txt = re.sub('"', '\\\\"', txt)
         txt = re.sub('@', '\\\\\\\\@', txt)
         txt = re.sub('\n', '\\\\n', txt)
+        # https://www.zotero.org/support/kb/rich_text_bibliography
+        # remove html tags from yaml and replace them with markdown formatting, if possible
+        txt = re.sub('<i>(.+?)</i>', '*\\1*', txt)
+        txt = re.sub('<b>(.+?)</b>', '**\\1**', txt)
+        txt = re.sub('<sub>(.+?)</sub>', '~\\1~', txt)
+        txt = re.sub('<sup>(.+?)</sup>', '^\\1^', txt)
+        txt = re.sub('<span style="font-variant:small-caps;">(.+?)</span>', '[\\1]{.smallcaps}', txt)
+        txt = re.sub('<span class="nocase">(.+?)</span>', '\\1', txt)
         return txt
 
     def _get_yaml_ref(self, entry, citekey):


### PR DESCRIPTION
- Zotero uses html tags for title formatting
- creating a pdf output from a markdown document using YAML references looses formatting because pandoc replaces e.g. "<i>...</i>" with "`<i>`{=html}...`</i>`{=html}", and thus pdf output will ignore the formatting
- substituting html tags with markdown formatting solves the issue
- _sanitize_yaml function in zotero.py is extended to make this substitutions (similarly to the substitutions in _get_bib_ref)