### PR TITLE
new remap to extract abstract

### DIFF
--- a/doc/zotcite.txt
+++ b/doc/zotcite.txt
@@ -121,6 +121,9 @@ In Vim's Normal mode, put the cursor over a citation key and press:
 
   - <Leader>za to see all fields of a reference as stored by Zotcite.
 
+  - <leader>zb to extract the abstract into the currently open buffer if its
+    available.
+
   - <Leader>zy to see how the reference will be converted into YAML.
 
   - <Leader>zv to view the (pdf or html) document generated from the current
@@ -214,6 +217,11 @@ To change the shortcut to see how the reference is converted into YAML, follow
 the example:
 >
  nmap ,Y <Plug>ZCitationYamlRef
+<
+To change the shortcut to extract the abstract into the current buffer from the
+abstract field in complete info:
+>
+ nmap ,Y <Plug>ZExtractAbstract 
 <
 To change the shortcut to view the (pdf or html) document generated from the
 current (Markdown, Rmd, or Quarto) document, follow the example:

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -17,12 +17,12 @@ local M = {}
 
 local b = {}
 
-M.show = function ()
+M.show = function()
     local info = {}
     for k, v in pairs(config) do
-        table.insert(info, { k, "Identifier" } )
-        table.insert(info, { " = ", "Operator" } )
-        table.insert(info, { vim.inspect(v) .. "\n" } )
+        table.insert(info, { k, "Identifier" })
+        table.insert(info, { " = ", "Operator" })
+        table.insert(info, { vim.inspect(v) .. "\n" })
     end
     vim.schedule(function() vim.api.nvim_echo(info, false, {}) end)
 end
@@ -41,7 +41,9 @@ M.update_config = function(opts)
     if config.exclude_fields then vim.env.Zotcite_exclude = config.exclude_fields end
     if config.year_page_sep then vim.env.ZYearPageSep = config.year_page_sep end
     if vim.env.Zotero_encoding then
-        zwarn("The environment variable `Zotero_encoding` now is a config option: `zotero_encoding`.")
+        zwarn(
+            "The environment variable `Zotero_encoding` now is a config option: `zotero_encoding`."
+        )
     end
     if config.zotero_encoding then vim.env.ZoteroEncoding = config.zotero_encoding end
 end
@@ -208,6 +210,12 @@ M.init = function()
             "<Leader>zy",
             "<Cmd>lua require('zotcite.get').yaml_ref()<CR>",
             "Zotcite: show reference as YAML"
+        )
+        create_map(
+            "<Plug>ZExtractAbstract",
+            "<leader>zb",
+            "<Cmd>lua require('zotcite.get').PasteAbstractNote()<CR>",
+            "Zotcite: Paste abstract note in current buffer"
         )
         vim.o.conceallevel = config.conceallevel
         require("zotcite.get").collection_name()

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -214,7 +214,7 @@ M.init = function()
         create_map(
             "<Plug>ZExtractAbstract",
             "<leader>zb",
-            "<Cmd>lua require('zotcite.get').PasteAbstractNote()<CR>",
+            "<Cmd>lua require('zotcite.get').abstract()<CR>",
             "Zotcite: Paste abstract note in current buffer"
         )
         vim.o.conceallevel = config.conceallevel

--- a/lua/zotcite/get.lua
+++ b/lua/zotcite/get.lua
@@ -176,6 +176,22 @@ M.reference_data = function(btype)
     end
 end
 
+M.PasteAbstractNote = function()
+    local wrd = M.citation_key()
+    if wrd ~= "" then
+        local repl = vim.fn.py3eval('ZotCite.GetRefData("' .. wrd .. '")')
+        if not repl then
+            zwarn("Citation key not found")
+            return
+        end
+        if repl.abstractNote then
+            vim.api.nvim_put({ repl.abstractNote }, "l", true, true)
+        else
+            zwarn("No abstract found associated with article")
+        end
+    end
+end
+
 M.refs = function(key)
     local mtchs = getmach(key)
     local info = {}

--- a/lua/zotcite/get.lua
+++ b/lua/zotcite/get.lua
@@ -176,7 +176,7 @@ M.reference_data = function(btype)
     end
 end
 
-M.PasteAbstractNote = function()
+M.abstract = function()
     local wrd = M.citation_key()
     if wrd ~= "" then
         local repl = vim.fn.py3eval('ZotCite.GetRefData("' .. wrd .. '")')


### PR DESCRIPTION
Here I have edited the docs for the new `<leader>zb` keymap and I have made a new function `PasteAbstractNote` in `get.lua` that gets the abstract as a string to paste into the current buffer. 

I am not sure if the mapping `:ZextractAbstract` is completely correct though and here this might need a bit of tweaking. 