### PR TITLE
open html attachments in zotero

### DIFF
--- a/lua/zotcite/get.lua
+++ b/lua/zotcite/get.lua
@@ -16,7 +16,10 @@ local M = {}
 local TranslateZPath = function(strg)
     local fpath = strg
 
-    if config.open_in_zotero and string.lower(strg):find("%.pdf$") then
+    if
+        config.open_in_zotero
+        and (string.lower(strg):find("%.pdf$") or string.lower(strg):find("%.html$"))
+    then
         local id = fpath:gsub(":.*", "")
         return "zotero://open-pdf/library/items/" .. id
     end


### PR DESCRIPTION
I would like to be able to open html attachments when `open_in_zotero` is set to true.