### PR TITLE
Web snapshot annotation fix

### DIFF
--- a/python3/zotero.py
+++ b/python3/zotero.py
@@ -883,7 +883,7 @@ class ZoteroEntries:
                     notes.append(i[7] + ' [@' + key + '#' + citekey + self._ypsep + page + ']')
             if i[6] and page is None: # Highlighted text, web snapshots
                 notes.append('')
-                notes.append('> ' + self._sanitize_markdown(i[6]) + ' [@' + key + '#' + citekey + ']')
+                notes.append('> ' + self._sanitize_markdown(i[6].replace("\n"," ")) + ' [@' + key + '#' + citekey + ']')
             elif i[6]: # Highlighted text
                 notes.append('')
                 notes.append('> ' + self._sanitize_markdown(i[6]) + ' [@' + key + '#' + citekey + self._ypsep + page + ']')

--- a/python3/zotero.py
+++ b/python3/zotero.py
@@ -857,21 +857,34 @@ class ZoteroEntries:
 
         notes = []
         for i in cur.fetchall():
-            mo = re.match("^[0-9]*$", i[8])
+            if i[8] is not None:
+                mo = re.match("^[0-9]*$", i[8])
+            else: # web snapshots
+                mo = None
             if mo is not None and mo.string == i[8]:
                 page = str(int(i[8]) + offset)
-            else:
+            elif i[8] is not None: 
                 page = i[8]
+            else: # web snapshots
+                page = None
             if i[7]: # Comment
                 notes.append('')
                 if i[7].find("\n") > -1:
                     ss = i[7].split("\n")
                     for s in ss:
                         notes.append(s)
-                    notes.append(' [@' + key + '#' + citekey + self._ypsep + page + ']')
+                    if page is None: # web snapshots
+                        notes.append(' [@' + key + '#' + citekey + ']')
+                    else:
+                        notes.append(' [@' + key + '#' + citekey + self._ypsep + page + ']')
+                elif page is None: # web snapshots
+                    notes.append(i[7] + ' [@' + key + '#' + citekey + ']')
                 else:
                     notes.append(i[7] + ' [@' + key + '#' + citekey + self._ypsep + page + ']')
-            if i[6]: # Highlighted text
+            if i[6] and page is None: # Highlighted text, web snapshots
+                notes.append('')
+                notes.append('> ' + self._sanitize_markdown(i[6]) + ' [@' + key + '#' + citekey + ']')
+            elif i[6]: # Highlighted text
                 notes.append('')
                 notes.append('> ' + self._sanitize_markdown(i[6]) + ' [@' + key + '#' + citekey + self._ypsep + page + ']')
         return notes


### PR DESCRIPTION
Zotero 7 added support to annotate web snapshots (html) by leaving option 'extensions.zotero.fileHandler.snapshot' empty. When I try to use `:Zselectannotations` following error occurs:
```
E5108: Error executing lua: function provider#python3#Call, line 1: Vim(return):E5108: Error executing lua Vim:Error invoking 'python_eval' on channel 3 (python3-script-host):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/t/.config/local/share/nvim/lazy/zotcite/python3/zotero.py", line 860, in GetAnnotations
    mo = re.match("^[0-9]*$", i[8])
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 167, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
stack traceback:
        [C]: at 0x6074254d333c
        [C]: in function 'py3eval'
        ...config/local/share/nvim/lazy/zotcite/lua/zotcite/get.lua:213: in function 'cb'
        ...onfig/local/share/nvim/lazy/zotcite/lua/zotcite/seek.lua:194: in function 'key_func'
        ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:252>
stack traceback:
        [C]: in function 'py3eval'
        ...config/local/share/nvim/lazy/zotcite/lua/zotcite/get.lua:213: in function 'cb'
        ...onfig/local/share/nvim/lazy/zotcite/lua/zotcite/seek.lua:194: in function 'key_func'
        ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:252>
```
It seems that in function `zotero.py/GetAnnotations()` when executing sqlite query for html annotation field `itemAnnotations.pageLabel` is empty. First commit adds some guardrails.


Second problem is with newlines in annotation text. When running `:Zannotations` on html snapshot following error occurs:
```
E5108: Error executing lua: /home/t/code/_import/zotcite/lua/zotcite/get.lua:208: 'replacement
string' item contains newlines
stack traceback:
        [C]: in function 'nvim_buf_set_lines'
        /home/t/code/_import/zotcite/lua/zotcite/get.lua:208: in function 'cb'
        /home/t/code/_import/zotcite/lua/zotcite/seek.lua:194: in function 'key_func'
        ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/n
vim/lazy/telescope.nvim/lua/telescope/mappings.lua:252>
```
These newlines also mess with '>' markdown block. If there are two newlines between paragraphs then second paragraph will be outside of '>' block which is bad because then it looks like a comment. So second commit fixes that.