### PR TITLE
Add support for Multifile latex \addbibresource discovery

### DIFF
--- a/doc/zotcite.txt
+++ b/doc/zotcite.txt
@@ -172,13 +172,13 @@ the correct path in your `config`. Example:
 >lua
  zotero_sqlite_path = '~/.zotero/zotero.sqlite'
 <
- 							  *tmpdir*
+								      *tmpdir*
 If Zotcite is trying to use a non-writable directory as its temporary and
 cache directory, set the value of `tmpdir`. Example:
 >lua
  tmpdir = '/dev/shm/zotcite-user_name'
-
- 							 *tex_fallback_root*
+<
+							   *tex_fallback_root*
 When editing LaTeX or Rnoweb documents, Zotcite first tries to find
 `\addbibresource{...}` in the current buffer, then in the file pointed by
 `% !TeX root = ...`. If both checks fail, Zotcite looks for a fallback root
@@ -186,7 +186,7 @@ file at `bufdir .. "/" .. tex_fallback_root`.
 The default is `"../main.tex"`. Example:
 >lua
  tex_fallback_root = "../main.tex"
-
+<
 Zotcite adds its `scripts` directory to the environment variable `PATH`. If
 it's not correctly finding the directory, you can set it manually:
 >lua

--- a/doc/zotcite.txt
+++ b/doc/zotcite.txt
@@ -172,11 +172,20 @@ the correct path in your `config`. Example:
 >lua
  zotero_sqlite_path = '~/.zotero/zotero.sqlite'
 <
-								      *tmpdir*
+ 							  *tmpdir*
 If Zotcite is trying to use a non-writable directory as its temporary and
 cache directory, set the value of `tmpdir`. Example:
 >lua
  tmpdir = '/dev/shm/zotcite-user_name'
+
+ 							 *tex_fallback_root*
+When editing LaTeX or Rnoweb documents, Zotcite first tries to find
+`\addbibresource{...}` in the current buffer, then in the file pointed by
+`% !TeX root = ...`. If both checks fail, Zotcite looks for a fallback root
+file at `bufdir .. "/" .. tex_fallback_root`.
+The default is `"../main.tex"`. Example:
+>lua
+ tex_fallback_root = "../main.tex"
 
 Zotcite adds its `scripts` directory to the environment variable `PATH`. If
 it's not correctly finding the directory, you can set it manually:

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -2,8 +2,7 @@ local zwarn = require("zotcite").zwarn
 
 local M = {}
 
-local find_tex_bib = function()
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+local extract_addbibresource = function(lines)
     for _, v in pairs(lines) do
         if v:find("\\addbibresource%{") then
             local bib = v:gsub("\\addbibresource%{", "")
@@ -11,6 +10,43 @@ local find_tex_bib = function()
             return bib
         end
     end
+    return nil
+end
+
+local read_lines = function(path)
+    if not path or vim.fn.filereadable(path) == 0 then return nil end
+    return vim.fn.readfile(path)
+end
+
+local find_root_file = function(lines)
+    for _, v in pairs(lines) do
+        local root = v:match("^%s*%%+%s*!%s*[Tt][Ee][Xx]%s+root%s*=%s*(.-)%s*$")
+        if root and root ~= "" then return root end
+    end
+    return nil
+end
+
+local find_tex_bib = function()
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+    local bib = extract_addbibresource(lines)
+    if bib then return bib end
+
+    local bufpath = vim.api.nvim_buf_get_name(0)
+    local bufdir = vim.fn.fnamemodify(bufpath, ":p:h")
+
+    local root = find_root_file(lines)
+    if root then
+        local rootpath = vim.fn.fnamemodify(bufdir .. "/" .. root, ":p")
+        local rootlines = read_lines(rootpath)
+        bib = rootlines and extract_addbibresource(rootlines) or nil
+        if bib then return bib end
+    end
+
+    local fallback_root = vim.fn.fnamemodify(bufdir .. "/../main.tex", ":p")
+    local fallback_lines = read_lines(fallback_root)
+    bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
+    if bib then return bib end
+
     zwarn("Could not find the '\\addbibresource' command.")
     return nil
 end

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -26,13 +26,19 @@ local find_root_file = function(lines)
     return nil
 end
 
+local resolve_path = function(base_dir, path)
+    if not path or path == "" then return path end
+    if path:match("^/") or path:match("^%a:[/\\]") then return path end
+    return vim.fn.fnamemodify(base_dir .. "/" .. path, ":p")
+end
+
 local find_tex_bib = function()
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-    local bib = extract_addbibresource(lines)
-    if bib then return bib end
-
     local bufpath = vim.api.nvim_buf_get_name(0)
     local bufdir = vim.fn.fnamemodify(bufpath, ":p:h")
+
+    local bib = extract_addbibresource(lines)
+    if bib then return resolve_path(bufdir, bib) end
 
     local root = find_root_file(lines)
     if root then
@@ -50,7 +56,8 @@ local find_tex_bib = function()
                     .. "'"
             )
         end
-        return bib
+        local rootdir = vim.fn.fnamemodify(rootpath, ":p:h")
+        return resolve_path(rootdir, bib)
     end
 
     local tfr = require("zotcite.config").get_config().tex_fallback_root
@@ -58,8 +65,8 @@ local find_tex_bib = function()
     local fallback_lines = read_lines(fallback_root)
     bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
     if bib then
-        bufdir = vim.fn.fnamemodify(fallback_root, ":p:h")
-        return bufdir .. "/" .. bib
+        local rootdir = vim.fn.fnamemodify(fallback_root, ":p:h")
+        return resolve_path(rootdir, bib)
     end
     zwarn("Could not find the '\\addbibresource' command.")
     return nil

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -42,7 +42,12 @@ local find_tex_bib = function()
         if bib then return bib end
     end
 
-    local fallback_root = vim.fn.fnamemodify(bufdir .. "/../main.tex", ":p")
+    local cfg = require("zotcite.config").get_config()
+    local fallback_suffix = cfg.tex_fallback_root
+    if type(fallback_suffix) ~= "string" or fallback_suffix == "" then
+        fallback_suffix = "../main.tex"
+    end
+    local fallback_root = vim.fn.fnamemodify(bufdir .. "/" .. fallback_suffix, ":p")
     local fallback_lines = read_lines(fallback_root)
     bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
     if bib then return bib end

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -42,7 +42,7 @@ local find_tex_bib = function()
 
     local root = find_root_file(lines)
     if root then
-        local rootpath = vim.fn.fnamemodify(bufdir .. "/" .. root, ":p")
+        local rootpath = resolve_path(bufdir, root)
         local rootlines = read_lines(rootpath)
         if not rootlines then
             zwarn("Failed to read TeX root: '" .. rootpath .. "'")

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -38,20 +38,29 @@ local find_tex_bib = function()
     if root then
         local rootpath = vim.fn.fnamemodify(bufdir .. "/" .. root, ":p")
         local rootlines = read_lines(rootpath)
-        bib = rootlines and extract_addbibresource(rootlines) or nil
-        if bib then return bib end
+        if not rootlines then
+            zwarn("Failed to read TeX root: '" .. rootpath .. "'")
+            return nil
+        end
+        bib = extract_addbibresource(rootlines)
+        if not bib then
+            zwarn(
+                "Could not find the '\\addbibresource' command in TeX root '"
+                    .. rootpath
+                    .. "'"
+            )
+        end
+        return bib
     end
 
-    local cfg = require("zotcite.config").get_config()
-    local fallback_suffix = cfg.tex_fallback_root
-    if type(fallback_suffix) ~= "string" or fallback_suffix == "" then
-        fallback_suffix = "../main.tex"
-    end
-    local fallback_root = vim.fn.fnamemodify(bufdir .. "/" .. fallback_suffix, ":p")
+    local tfr = require("zotcite.config").get_config().tex_fallback_root
+    local fallback_root = vim.fn.fnamemodify(bufdir .. "/" .. tfr, ":p")
     local fallback_lines = read_lines(fallback_root)
     bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
-    if bib then return bib end
-
+    if bib then
+        bufdir = vim.fn.fnamemodify(fallback_root, ":p:h")
+        return bufdir .. "/" .. bib
+    end
     zwarn("Could not find the '\\addbibresource' command.")
     return nil
 end

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -63,7 +63,7 @@ local config = {
         "vimwiki",
     },
     python_path = "python3",
-    pdf_extractor = "pdfnotes.py", -- Default: "pdfnotes.py", alternative: "pdfnotes2.py"
+    pdf_extractor = "pdfnotes.py",
     tex_fallback_root = "../main.tex",
 }
 

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -40,6 +40,9 @@
 ---Space separated list of title words to be
 ---excluded from citation keys
 ---@field banned_words? string
+---Relative path from buffer directory to a fallback TeX root file
+---used when no `% !TeX root = ...` is found
+---@field tex_fallback_root? string
 
 ---@type ZotciteUserOpts
 local config = {
@@ -61,6 +64,7 @@ local config = {
     },
     python_path = "python3",
     pdf_extractor = "pdfnotes.py", -- Default: "pdfnotes.py", alternative: "pdfnotes2.py"
+    tex_fallback_root = "../main.tex",
 }
 
 local did_global_init = false


### PR DESCRIPTION
This PR fixes #136 by first attempting to find \addbibresource in the current buffer (old behavior) and if that fails tries to parse a potential magic comment at the top of the tex files (i.e. something like: "% !TeX root = ../main.tex"), which is a somewhat common practice in Multifile latex projects.
If we cannot find a magic comment or we do not find the \addbibresource there, a global fallback path is used, which is configurable in the lazy setup (default tex_fallback_root = "../main.tex").

The update should be fully backward compatible and the doc/zotcite.txt file was adjusted to document the new tex_fallback_root option.

Small disclaimer, the code for this PR was generated with the help of AI (ChatGPT 5.3 codex) but I tried to thoroughly review and test it in my own latex vim setup. As I am not very experience with Lua, I would be happy if somebody could check for obvious red flags.

Thank you for considering the PR!