### PR TITLE
Add an option to look for bibliography files relative to the current buffer

### DIFF
--- a/doc/zotcite.txt
+++ b/doc/zotcite.txt
@@ -178,6 +178,13 @@ cache directory, set the value of `tmpdir`. Example:
 >lua
  tmpdir = '/dev/shm/zotcite-user_name'
 <
+							     *bib_relative_to*
+Zotcite will use the directory of the buffer being edited as the relative path
+to save Bib files, but you can change the relative path to the current working
+directory:
+>lua
+ bib_relative_to = "working_dir"
+<
 							   *tex_fallback_root*
 When editing LaTeX or Rnoweb documents, Zotcite first tries to find
 `\addbibresource{...}` in the current buffer, then in the file pointed by

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -32,15 +32,15 @@ local resolve_path = function(base_dir, path)
     return vim.fn.fnamemodify(base_dir .. "/" .. path, ":p")
 end
 
-local find_tex_bib = function(bufdir)
+local find_tex_bib = function(dir)
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
 
     local bib = extract_addbibresource(lines)
-    if bib then return resolve_path(bufdir, bib) end
+    if bib then return resolve_path(dir, bib) end
 
     local root = find_root_file(lines)
     if root then
-        local rootpath = resolve_path(bufdir, root)
+        local rootpath = resolve_path(dir, root)
         local rootlines = read_lines(rootpath)
         if not rootlines then
             zwarn("Failed to read TeX root: '" .. rootpath .. "'")
@@ -59,7 +59,7 @@ local find_tex_bib = function(bufdir)
     end
 
     local tfr = require("zotcite.config").get_config().tex_fallback_root
-    local fallback_root = vim.fn.fnamemodify(bufdir .. "/" .. tfr, ":p")
+    local fallback_root = vim.fn.fnamemodify(dir .. "/" .. tfr, ":p")
     local fallback_lines = read_lines(fallback_root)
     bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
     if bib then
@@ -70,25 +70,25 @@ local find_tex_bib = function(bufdir)
     return nil
 end
 
-local find_typst_bib = function(bufdir)
+local find_typst_bib = function(dir)
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
     for _, v in pairs(lines) do
         if v and v:find("#bibliography%(") then
-            return resolve_path(bufdir, v:match('#bibliography%(%s*"(%S-)".*'))
+            return resolve_path(dir, v:match('#bibliography%(%s*"(%S-)".*'))
         end
     end
     zwarn("Could not find the `#bibliography` identifier.")
     return nil
 end
 
-local find_markdown_bib = function(bufdir)
+local find_markdown_bib = function(dir)
     local ybib = require("zotcite.get").yaml_field("bibliography", 0)
     if not ybib then
         zwarn("Could not find 'bibliography' field in YAML header.")
         return nil
     end
 
-    if type(ybib) == "string" then return resolve_path(bufdir, ybib) end
+    if type(ybib) == "string" then return resolve_path(dir, ybib) end
 
     local bib = nil
     if type(ybib) == "table" then
@@ -107,14 +107,14 @@ end
 
 local find_bib_fn = function()
     local brt = require("zotcite.config").get_config().bib_relative_to
-    local bibdir = brt == "working_dir" and vim.uv.cwd()
+    local dir = brt == "working_dir" and vim.uv.cwd()
         or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":p:h")
     if vim.bo.filetype == "typst" then
-        return find_typst_bib(bibdir)
+        return find_typst_bib(dir)
     elseif vim.bo.filetype == "tex" or vim.bo.filetype == "rnoweb" then
-        return find_tex_bib(bibdir)
+        return find_tex_bib(dir)
     end
-    return find_markdown_bib(bibdir)
+    return find_markdown_bib(dir)
 end
 
 local get_typ_citations = function(kz)

--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -28,14 +28,12 @@ end
 
 local resolve_path = function(base_dir, path)
     if not path or path == "" then return path end
-    if path:match("^/") or path:match("^%a:[/\\]") then return path end
+    if path:find("^/") or path:find("^%a:[/\\]") then return path end
     return vim.fn.fnamemodify(base_dir .. "/" .. path, ":p")
 end
 
-local find_tex_bib = function()
+local find_tex_bib = function(bufdir)
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-    local bufpath = vim.api.nvim_buf_get_name(0)
-    local bufdir = vim.fn.fnamemodify(bufpath, ":p:h")
 
     local bib = extract_addbibresource(lines)
     if bib then return resolve_path(bufdir, bib) end
@@ -72,25 +70,25 @@ local find_tex_bib = function()
     return nil
 end
 
-local find_typst_bib = function()
+local find_typst_bib = function(bufdir)
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
     for _, v in pairs(lines) do
         if v and v:find("#bibliography%(") then
-            return v:match('#bibliography%(%s*"(%S-)".*')
+            return resolve_path(bufdir, v:match('#bibliography%(%s*"(%S-)".*'))
         end
     end
     zwarn("Could not find the `#bibliography` identifier.")
     return nil
 end
 
-local find_markdown_bib = function()
+local find_markdown_bib = function(bufdir)
     local ybib = require("zotcite.get").yaml_field("bibliography", 0)
     if not ybib then
         zwarn("Could not find 'bibliography' field in YAML header.")
         return nil
     end
 
-    if type(ybib) == "string" then return ybib end
+    if type(ybib) == "string" then return resolve_path(bufdir, ybib) end
 
     local bib = nil
     if type(ybib) == "table" then
@@ -108,11 +106,15 @@ local find_markdown_bib = function()
 end
 
 local find_bib_fn = function()
-    if vim.bo.filetype == "typst" then return find_typst_bib() end
-    if vim.bo.filetype == "tex" or vim.bo.filetype == "rnoweb" then
-        return find_tex_bib()
+    local brt = require("zotcite.config").get_config().bib_relative_to
+    local bibdir = brt == "working_dir" and vim.uv.cwd()
+        or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":p:h")
+    if vim.bo.filetype == "typst" then
+        return find_typst_bib(bibdir)
+    elseif vim.bo.filetype == "tex" or vim.bo.filetype == "rnoweb" then
+        return find_tex_bib(bibdir)
     end
-    return find_markdown_bib()
+    return find_markdown_bib(bibdir)
 end
 
 local get_typ_citations = function(kz)

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -43,8 +43,8 @@
 ---Relative path from buffer directory to a fallback TeX root file
 ---used when no `% !TeX root = ...` is found
 ---@field tex_fallback_root? string
----Look for bibliography files relative to the CWD (default) or the file in the buffer
----@field bib_relative_to? string '"working_dir"' | '"file_dir"'
+---Look for bibliography files relative to the current file (default) or working directory
+---@field bib_relative_to? string '"file_dir"' | '"working_dir"'
 
 ---@type ZotciteUserOpts
 local config = {
@@ -67,7 +67,7 @@ local config = {
     python_path = "python3",
     pdf_extractor = "pdfnotes.py",
     tex_fallback_root = "../main.tex",
-    bib_relative_to = "working_dir", -- Default: "working_dir", alternative: "file_dir"
+    bib_relative_to = "file_dir",
 }
 
 local did_global_init = false

--- a/lua/zotcite/config.lua
+++ b/lua/zotcite/config.lua
@@ -43,6 +43,8 @@
 ---Relative path from buffer directory to a fallback TeX root file
 ---used when no `% !TeX root = ...` is found
 ---@field tex_fallback_root? string
+---Look for bibliography files relative to the CWD (default) or the file in the buffer
+---@field bib_relative_to? string '"working_dir"' | '"file_dir"'
 
 ---@type ZotciteUserOpts
 local config = {
@@ -65,6 +67,7 @@ local config = {
     python_path = "python3",
     pdf_extractor = "pdfnotes.py",
     tex_fallback_root = "../main.tex",
+    bib_relative_to = "working_dir", -- Default: "working_dir", alternative: "file_dir"
 }
 
 local did_global_init = false

--- a/lua/zotcite/zotero.lua
+++ b/lua/zotcite/zotero.lua
@@ -713,8 +713,12 @@ end
 function M.update_bib(zkeys, bibf, ktype, verbose)
     local bib = {}
 
-    if config.bib_relative_to == "file_dir" then
-        bibf = vim.fn.substitute(vim.fn.expand("%:p"),[[^\(.*[/\\]\)[^/\\]*$]],[[\1]],'e') .. "/" .. bibf
+    if config.bib_relative_to == "file_dir" and not bibf:find("^/") then
+        local bpath = vim.api.nvim_buf_get_name(0)
+        if vim.uv.os_uname().sysname:find("Windows", 1, true) then
+            bpath = bpath:gsub("\\", "/")
+        end
+        bibf = bpath:gsub("(.*/).*", "%1") .. bibf
     end
 
     local f = io.open(bibf, "r")

--- a/lua/zotcite/zotero.lua
+++ b/lua/zotcite/zotero.lua
@@ -713,6 +713,10 @@ end
 function M.update_bib(zkeys, bibf, ktype, verbose)
     local bib = {}
 
+    if config.bib_relative_to == "file_dir" then
+        bibf = vim.fn.substitute(vim.fn.expand("%:p"),[[^\(.*[/\\]\)[^/\\]*$]],[[\1]],'e') .. "/" .. bibf
+    end
+
     local f = io.open(bibf, "r")
     if f then
         if verbose then zwarn('zotcite: updating "' .. tostring(bibf) .. '"\n') end

--- a/lua/zotcite/zotero.lua
+++ b/lua/zotcite/zotero.lua
@@ -713,14 +713,6 @@ end
 function M.update_bib(zkeys, bibf, ktype, verbose)
     local bib = {}
 
-    if config.bib_relative_to == "file_dir" and not bibf:find("^/") then
-        local bpath = vim.api.nvim_buf_get_name(0)
-        if vim.uv.os_uname().sysname:find("Windows", 1, true) then
-            bpath = bpath:gsub("\\", "/")
-        end
-        bibf = bpath:gsub("(.*/).*", "%1") .. bibf
-    end
-
     local f = io.open(bibf, "r")
     if f then
         if verbose then zwarn('zotcite: updating "' .. tostring(bibf) .. '"\n') end


### PR DESCRIPTION
Add a config option to look treat the bibliography file as relative to the current buffer rather than to the current working directory.

My current directory is pretty much always `$HOME`, and calling chdir before each write wouldn't be workable for me because I am usually jumping around different folders within a wiki. Absolute paths would also not be ideal.

The vim.fn.substitute pattern comes from the implementation of `:Explore`.