### PR TITLE
Support for latex package cite in addition to biblatex

### DIFF
--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -13,6 +13,17 @@ local extract_addbibresource = function(lines)
     return nil
 end
 
+local extract_bibliography_texcmd = function(lines)
+    for _, v in pairs(lines) do
+        if v:find("\\bibliography%{") then
+            local bib = v:gsub("\\bibliography%{", "")
+            bib = bib:gsub("}.*", ".bib")
+            return bib
+        end
+    end
+    return nil
+end
+
 local read_lines = function(path)
     if not path or vim.fn.filereadable(path) == 0 then return nil end
     return vim.fn.readfile(path)
@@ -35,7 +46,7 @@ end
 local find_tex_bib = function(dir)
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
 
-    local bib = extract_addbibresource(lines)
+    local bib = extract_addbibresource(lines) or extract_bibliography_texcmd(lines)
     if bib then return resolve_path(dir, bib) end
 
     local root = find_root_file(lines)
@@ -46,10 +57,10 @@ local find_tex_bib = function(dir)
             zwarn("Failed to read TeX root: '" .. rootpath .. "'")
             return nil
         end
-        bib = extract_addbibresource(rootlines)
+        bib = extract_addbibresource(rootlines) or extract_bibliography_texcmd(lines)
         if not bib then
             zwarn(
-                "Could not find the '\\addbibresource' command in TeX root '"
+                "Could not find the '\\addbibresource' or '\bibliography' command in TeX root '"
                     .. rootpath
                     .. "'"
             )
@@ -61,12 +72,12 @@ local find_tex_bib = function(dir)
     local tfr = require("zotcite.config").get_config().tex_fallback_root
     local fallback_root = vim.fn.fnamemodify(dir .. "/" .. tfr, ":p")
     local fallback_lines = read_lines(fallback_root)
-    bib = fallback_lines and extract_addbibresource(fallback_lines) or nil
+    bib = fallback_lines and (extract_addbibresource(fallback_lines) or extract_bibliography_texcmd(fallback_lines) or nil)
     if bib then
         local rootdir = vim.fn.fnamemodify(fallback_root, ":p:h")
         return resolve_path(rootdir, bib)
     end
-    zwarn("Could not find the '\\addbibresource' command.")
+    zwarn("Could not find the '\\addbibresource' or '\\bibliography' command.")
     return nil
 end
 


### PR DESCRIPTION
The latex `cite` [package](https://ctan.org/tex-archive/macros/latex/contrib/cite) is commonly used for numeric citations. It doesn't use `addbibresource`, it uses `bibliography` instead. This PR adds a lookup for the `bibliography` latex command, which expects bib files to be provided without the `.bib` suffix.

Alternatively, the `extract_addbibresource` function could sub out anything in the line preceding the `addbibresource` command, enabling users to work around not using `biblatex` by putting an `addbibresource` command in a comment:

`            local bib = v:gsub("\\addbibresource%{", "")`
to
`            local bib = v:gsub("^.*\\addbibresource%{", "")`