### PR TITLE
Fix false-positive citation detection for URLs 

### DIFF
--- a/lua/zotcite/bib.lua
+++ b/lua/zotcite/bib.lua
@@ -155,7 +155,8 @@ local get_md_citations = function(kz)
         while true do
             local s, e = v:find(kp, i)
             if not s or not e then break end
-            table.insert(ckeys, v:sub(s + 1, e))
+            local prevchar = s > 1 and v:sub(s - 1, s - 1) or ""
+            if not prevchar:find("[%w/]") then table.insert(ckeys, v:sub(s + 1, e)) end
             i = e + 1
         end
     end


### PR DESCRIPTION
Fix false-positive citation detection for URLs like https://www.example.com/@handle/

Previously this caused zotcite to always warn "Could not find 'bibliography' field in YAML header" on file save.